### PR TITLE
Update deploy.yml to simulate database service in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,10 +55,12 @@ jobs:
           for i in {1..30}; do
             if mysqladmin ping -h127.0.0.1 -uroot -proot --silent; then
               echo "MySQL is up!"
-              break
+              exit 0
             fi
             sleep 2
           done
+          echo "Error: MySQL did not become ready after 30 attempts."
+          exit 1
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,31 @@ name: Build and Push Property Microservice Docker Image
 on:
   push:
     branches: ["develop"]
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_DATABASE: testdb
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    env:
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_NAME: testdb
+      DB_USERNAME: root
+      DB_PASSWORD: root
 
     steps:
       - name: Checkout repository
@@ -27,6 +49,17 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
+
+      - name: Wait for MySQL to be ready
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h127.0.0.1 -uroot -proot --silent; then
+              echo "MySQL is up!"
+              break
+            fi
+            sleep 2
+          done
+
       - name: Build with Gradle
         run: ./gradlew build
 


### PR DESCRIPTION
This PR updates the GitHub Actions deploy.yml workflow to include a MySQL service and environment variables required for database integration during the build process. This ensures that database-dependent tests run successfully in the CI environment.

Key changes:

    Added MySQL as a service in the workflow.
    Set environment variables (DB_HOST, DB_PORT, DB_NAME, DB_USERNAME, DB_PASSWORD) for database connection.
    Added a step to wait for MySQL to be ready before running the build.
    Ensured consistency between local and CI database configurations.

Why?

By simulating the database in CI, we can catch integration issues earlier and make sure our tests reflect real-world usage more closely.

Notes:

    No application code changes, only workflow adjustments.
    Please review and suggest any improvements for further reliability.
